### PR TITLE
Add `TypeRegistration::on_register`

### DIFF
--- a/crates/bevy_reflect/derive/src/registration.rs
+++ b/crates/bevy_reflect/derive/src/registration.rs
@@ -16,10 +16,15 @@ pub(crate) fn impl_get_type_registration<'a>(
 
     let type_deps_fn = type_dependencies.map(|deps| {
         quote! {
-            #[inline(never)]
-            fn register_type_dependencies(registry: &mut #bevy_reflect_path::TypeRegistry) {
-                #(<#deps as #bevy_reflect_path::__macro_exports::RegisterForReflection>::__register(registry);)*
-            }
+            #(<#deps as #bevy_reflect_path::__macro_exports::RegisterForReflection>::__register(registry);)*
+        }
+    });
+
+    let on_register = type_deps_fn.map(|func| {
+        quote! {
+            .on_register(|registry| {
+                #func
+            })
         }
     });
 
@@ -70,9 +75,8 @@ pub(crate) fn impl_get_type_registration<'a>(
                 #from_reflect_data
                 #serialization_data
                 #(#type_data)*
+                #on_register
             }
-
-            #type_deps_fn
         }
     }
 }

--- a/crates/bevy_reflect/src/impls/alloc/borrow.rs
+++ b/crates/bevy_reflect/src/impls/alloc/borrow.rs
@@ -6,8 +6,7 @@ use crate::{
     reflect::{impl_full_reflect, ApplyError},
     type_info::{MaybeTyped, OpaqueInfo, TypeInfo, Typed},
     type_registry::{
-        GetTypeRegistration, ReflectDeserialize, ReflectFromPtr, ReflectSerialize,
-        TypeRegistration, TypeRegistry,
+        GetTypeRegistration, ReflectDeserialize, ReflectFromPtr, ReflectSerialize, TypeRegistration,
     },
     utility::{reflect_hasher, GenericTypeInfoCell, NonGenericTypeInfoCell},
 };
@@ -291,11 +290,9 @@ impl<T: FromReflect + MaybeTyped + Clone + TypePath + GetTypeRegistration> GetTy
     for Cow<'static, [T]>
 {
     fn get_type_registration() -> TypeRegistration {
-        TypeRegistration::of::<Cow<'static, [T]>>()
-    }
-
-    fn register_type_dependencies(registry: &mut TypeRegistry) {
-        registry.register::<T>();
+        TypeRegistration::of::<Cow<'static, [T]>>().on_register(|registry| {
+            registry.register::<T>();
+        })
     }
 }
 

--- a/crates/bevy_reflect/src/impls/core/primitives.rs
+++ b/crates/bevy_reflect/src/impls/core/primitives.rs
@@ -6,8 +6,7 @@ use crate::{
     reflect::ApplyError,
     type_info::{MaybeTyped, OpaqueInfo, TypeInfo, Typed},
     type_registry::{
-        GetTypeRegistration, ReflectDeserialize, ReflectFromPtr, ReflectSerialize,
-        TypeRegistration, TypeRegistry,
+        GetTypeRegistration, ReflectDeserialize, ReflectFromPtr, ReflectSerialize, TypeRegistration,
     },
     utility::{reflect_hasher, GenericTypeInfoCell, GenericTypePathCell, NonGenericTypeInfoCell},
 };
@@ -639,11 +638,9 @@ impl<T: Reflect + MaybeTyped + TypePath + GetTypeRegistration, const N: usize> G
     for [T; N]
 {
     fn get_type_registration() -> TypeRegistration {
-        TypeRegistration::of::<[T; N]>()
-    }
-
-    fn register_type_dependencies(registry: &mut TypeRegistry) {
-        registry.register::<T>();
+        TypeRegistration::of::<[T; N]>().on_register(|registry| {
+            registry.register::<T>();
+        })
     }
 }
 

--- a/crates/bevy_reflect/src/impls/indexmap.rs
+++ b/crates/bevy_reflect/src/impls/indexmap.rs
@@ -8,7 +8,7 @@ use crate::{
 use bevy_platform::prelude::{Box, Vec};
 use bevy_reflect::{
     map::{DynamicMap, Map, MapInfo},
-    MaybeTyped, ReflectFromReflect, ReflectKind, TypeRegistry, Typed,
+    MaybeTyped, ReflectFromReflect, ReflectKind, Typed,
 };
 use bevy_reflect_derive::impl_type_path;
 use core::{any::Any, hash::BuildHasher, hash::Hash};
@@ -268,11 +268,10 @@ where
         TypeRegistration::of::<Self>()
             .register_type_data::<ReflectFromPtr, Self>()
             .register_type_data::<ReflectFromReflect, Self>()
-    }
-
-    fn register_type_dependencies(registry: &mut TypeRegistry) {
-        registry.register::<K>();
-        registry.register::<V>();
+            .on_register(|registry| {
+                registry.register::<K>();
+                registry.register::<V>();
+            })
     }
 }
 

--- a/crates/bevy_reflect/src/impls/macros/list.rs
+++ b/crates/bevy_reflect/src/impls/macros/list.rs
@@ -161,10 +161,9 @@ macro_rules! impl_reflect_for_veclike {
                     $crate::type_registry::TypeRegistration::of::<$ty>()
                         .register_type_data::<$crate::type_registry::ReflectFromPtr, $ty>()
                         .register_type_data::<$crate::from_reflect::ReflectFromReflect, $ty>()
-                }
-
-                fn register_type_dependencies(registry: &mut $crate::type_registry::TypeRegistry) {
-                    registry.register::<T>();
+                        .on_register(|registry| {
+                            registry.register::<T>();
+                        })
                 }
             }
 

--- a/crates/bevy_reflect/src/impls/macros/map.rs
+++ b/crates/bevy_reflect/src/impls/macros/map.rs
@@ -204,11 +204,10 @@ macro_rules! impl_reflect_for_hashmap {
                     $crate::type_registry::TypeRegistration::of::<Self>()
                         .register_type_data::<$crate::type_registry::ReflectFromPtr, Self>()
                         .register_type_data::<$crate::from_reflect::ReflectFromReflect, Self>()
-                }
-
-                fn register_type_dependencies(registry: &mut $crate::type_registry::TypeRegistry) {
-                    registry.register::<K>();
-                    registry.register::<V>();
+                        .on_register(|registry| {
+                            registry.register::<K>();
+                            registry.register::<V>();
+                        })
                 }
             }
 

--- a/crates/bevy_reflect/src/impls/macros/set.rs
+++ b/crates/bevy_reflect/src/impls/macros/set.rs
@@ -167,10 +167,9 @@ macro_rules! impl_reflect_for_hashset {
                     $crate::type_registry::TypeRegistration::of::<Self>()
                         .register_type_data::<$crate::type_registry::ReflectFromPtr, Self>()
                         .register_type_data::<$crate::from_reflect::ReflectFromReflect, Self>()
-                }
-
-                fn register_type_dependencies(registry: &mut $crate::type_registry::TypeRegistry) {
-                    registry.register::<V>();
+                        .on_register(|registry| {
+                            registry.register::<V>();
+                        })
                 }
             }
 

--- a/crates/bevy_reflect/src/tuple.rs
+++ b/crates/bevy_reflect/src/tuple.rs
@@ -8,8 +8,8 @@ use crate::generics::impl_generic_info_methods;
 use crate::{
     type_info::impl_type_methods, utility::GenericTypePathCell, ApplyError, FromReflect, Generics,
     GetTypeRegistration, MaybeTyped, PartialReflect, Reflect, ReflectCloneError, ReflectKind,
-    ReflectMut, ReflectOwned, ReflectRef, Type, TypeInfo, TypePath, TypeRegistration, TypeRegistry,
-    Typed, UnnamedField,
+    ReflectMut, ReflectOwned, ReflectRef, Type, TypeInfo, TypePath, TypeRegistration, Typed,
+    UnnamedField,
 };
 use alloc::{boxed::Box, vec, vec::Vec};
 use core::{
@@ -667,11 +667,9 @@ macro_rules! impl_reflect_tuple {
 
         impl<$($name: Reflect + MaybeTyped + TypePath + GetTypeRegistration),*> GetTypeRegistration for ($($name,)*) {
             fn get_type_registration() -> TypeRegistration {
-                TypeRegistration::of::<($($name,)*)>()
-            }
-
-            fn register_type_dependencies(_registry: &mut TypeRegistry) {
-                $(_registry.register::<$name>();)*
+                TypeRegistration::of::<($($name,)*)>().on_register(|_registry| {
+                    $(_registry.register::<$name>();)*
+                })
             }
         }
 

--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -81,6 +81,10 @@ pub trait GetTypeRegistration: 'static {
     ///
     /// This method is called by [`TypeRegistry::register`] to register any other required types.
     /// Often, this is done for fields of structs and enum variants to ensure all types are properly registered.
+    #[deprecated(
+        since = "0.20.0",
+        note = "This function will be removed in a future release. Please use `TypeRegistration::on_register` instead."
+    )]
     fn register_type_dependencies(_registry: &mut TypeRegistry) {}
 }
 
@@ -205,6 +209,10 @@ impl TypeRegistry {
         T: GetTypeRegistration,
     {
         if self.register_internal(TypeId::of::<T>(), T::get_type_registration, false) {
+            #[expect(
+                deprecated,
+                reason = "will continue to use `GetTypeRegistration::register_type_dependencies` until fully removed"
+            )]
             T::register_type_dependencies(self);
         }
     }
@@ -302,8 +310,13 @@ impl TypeRegistry {
         );
 
         let callbacks = registration.flush_on_register_callbacks();
+        let on_register = registration.on_register.take();
 
         self.registrations.insert(type_id, registration);
+
+        if let Some(on_register) = on_register {
+            on_register(self);
+        }
 
         for callback in callbacks {
             callback.call(self);
@@ -898,6 +911,7 @@ macro_rules! type_data_insertion_methods {
 pub struct TypeRegistration {
     data: TypeIdMap<Box<dyn TypeData>>,
     type_info: &'static TypeInfo,
+    on_register: Option<Box<dyn FnOnce(&mut TypeRegistry) + Send + Sync + 'static>>,
     /// The `on_register` callbacks waiting to be applied.
     ///
     /// These are generally the ones from [`CreateTypeData::on_register`]
@@ -921,12 +935,106 @@ impl Debug for TypeRegistration {
 
 impl TypeRegistration {
     /// Creates type registration information for `T`.
+    ///
+    /// Note that this creates an empty type registration for `T`.
+    /// To ensure all dependencies and type data are registered for `T`,
+    /// it's recommended to use [`GetTypeRegistration::get_type_registration`] instead.
     pub fn of<T: Reflect + Typed + TypePath>() -> Self {
         Self {
             data: Default::default(),
             type_info: T::type_info(),
             pending_callbacks: None,
+            on_register: None,
         }
+    }
+
+    /// Register a callback for when this [`TypeRegistration`] is registered into a [`TypeRegistry`].
+    ///
+    /// This can be used to register type dependencies or perform other registry logic.
+    ///
+    /// If a callback was already defined, a new closure will be defined that first runs the existing
+    /// callback followed by the new callback, `f`.
+    /// This is generally what you want if the registration was returned by something like [`GetTypeRegistration::get_type_registration`].
+    /// However, if you need to completely replace the existing callback, if any, see [`Self::replace_on_register`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use core::any::TypeId;
+    /// # use bevy_reflect::{Reflect, TypeRegistration, TypeRegistry};
+    /// #[derive(Reflect)]
+    /// struct MyType;
+    ///
+    /// let registration = TypeRegistration::of::<MyType>()
+    ///   .on_register(|registry| {
+    ///     registry.register::<Option<MyType>>();
+    ///   })
+    ///   // Add another callback in addition to the one above
+    ///   .on_register(|registry| {
+    ///     registry.register::<Vec<MyType>>();
+    ///   });
+    ///
+    /// let mut registry = TypeRegistry::new();
+    /// registry.add_registration(registration);
+    ///
+    /// assert!(registry.contains(TypeId::of::<MyType>()));
+    /// assert!(registry.contains(TypeId::of::<Option<MyType>>()));
+    /// assert!(registry.contains(TypeId::of::<Vec<MyType>>()));
+    /// ```
+    pub fn on_register<F: FnOnce(&mut TypeRegistry) + Send + Sync + 'static>(
+        mut self,
+        f: F,
+    ) -> Self {
+        self.on_register = if let Some(existing) = self.on_register.take() {
+            Some(Box::new(|registry| {
+                existing(registry);
+                f(registry);
+            }))
+        } else {
+            Some(Box::new(f))
+        };
+
+        self
+    }
+
+    /// Register a callback for when this [`TypeRegistration`] is registered into a [`TypeRegistry`].
+    /// If a callback was already defined for this registration, it will be replaced.
+    ///
+    /// This can be used to register type dependencies or perform other registry logic.
+    ///
+    /// In most cases, except where you have manually created the [`TypeRegistration`] using [`TypeRegistration::of`],
+    /// it is preferred to use [`TypeRegistration::on_register`] to preserve existing callback logic.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use core::any::TypeId;
+    /// # use bevy_reflect::{Reflect, TypeRegistration, TypeRegistry};
+    /// #[derive(Reflect)]
+    /// struct MyType;
+    ///
+    /// let registration = TypeRegistration::of::<MyType>()
+    ///   .on_register(|registry| {
+    ///     registry.register::<Option<MyType>>();
+    ///   })
+    ///   // Overwrite the callback above
+    ///   .replace_on_register(|registry| {
+    ///     registry.register::<Vec<MyType>>();
+    ///   });
+    ///
+    /// let mut registry = TypeRegistry::new();
+    /// registry.add_registration(registration);
+    ///
+    /// assert!(registry.contains(TypeId::of::<MyType>()));
+    /// assert!(!registry.contains(TypeId::of::<Option<MyType>>()));
+    /// assert!(registry.contains(TypeId::of::<Vec<MyType>>()));
+    /// ```
+    pub fn replace_on_register<F: FnOnce(&mut TypeRegistry) + Send + Sync + 'static>(
+        mut self,
+        f: F,
+    ) -> Self {
+        self.on_register = Some(Box::new(f));
+        self
     }
 
     /// Inserts an instance of `T` into this registration's [type data].
@@ -1244,7 +1352,7 @@ impl<T: Reflect> CreateTypeData<T> for ReflectFromPtr {
     unsafe_code,
     reason = "We must interact with pointers here, which are inherently unsafe."
 )]
-mod test {
+mod tests {
     use super::*;
 
     #[test]
@@ -1332,5 +1440,63 @@ mod test {
 
         let data = registration.data::<DataA>().unwrap();
         assert_eq!(data.0, 456);
+    }
+
+    #[test]
+    fn should_allow_replacing_on_register() {
+        #[derive(Reflect)]
+        struct MyType;
+
+        #[derive(Reflect)]
+        struct Good;
+
+        #[derive(Reflect)]
+        struct Bad;
+
+        let registration = TypeRegistration::of::<MyType>()
+            // Initial on_register
+            .on_register(|registry| {
+                registry.register::<Bad>();
+            })
+            // New on_register
+            .replace_on_register(|registry| {
+                registry.register::<Good>();
+            });
+
+        let mut registry = TypeRegistry::empty();
+        registry.add_registration(registration);
+
+        assert!(registry.contains(TypeId::of::<MyType>()));
+        assert!(registry.contains(TypeId::of::<Good>()));
+        assert!(!registry.contains(TypeId::of::<Bad>()));
+    }
+
+    #[test]
+    fn should_allow_appending_on_register() {
+        #[derive(Reflect)]
+        struct MyType;
+
+        #[derive(Reflect)]
+        struct One;
+
+        #[derive(Reflect)]
+        struct Two;
+
+        let registration = TypeRegistration::of::<MyType>()
+            // Initial on_register
+            .on_register(|registry| {
+                registry.register::<One>();
+            })
+            // Added on_register
+            .on_register(|registry| {
+                registry.register::<Two>();
+            });
+
+        let mut registry = TypeRegistry::empty();
+        registry.add_registration(registration);
+
+        assert!(registry.contains(TypeId::of::<MyType>()));
+        assert!(registry.contains(TypeId::of::<One>()));
+        assert!(registry.contains(TypeId::of::<Two>()));
     }
 }


### PR DESCRIPTION
# Objective

Followup to #24518.

#24518 makes it so that type data can be given `on_insert` and `on_register` callbacks. This enables users to add dependencies and other registry/registration operations in a much more flexible way.

My goal with this PR is to unify that experience for `GetTypeRegistration`. This would also allow us to run these callbacks even for a dynamically generated `TypeRegistration` (since we normally only run `GetTypeRegistration::register_type_dependencies` via `TypeRegistry::register` where the type of `T` is known at compile time).

## Solution

This PR deprecates `GetTypeRegistration::register_type_dependencies` in favor of a new `TypeRegistration::on_register` callback system.

```rust
impl GetTypeRegistration for MyType {
  fn get_type_registration() -> TypeRegistration {
    TypeRegistration::of::<Self>()
      .on_register(|registry| {
        registry.register::<Option<Self>>();
      })
  }
}
```

`TypeRegistration::on_register` accepts a `FnOnce(&mut TypeRegistry) + Send + Sync + 'static` and runs when a type is registered into a `TypeRegistry`.

I chose to make it so that by default `TypeRegistration::on_register` will wrap any existing callback, running the old run first then the new one on registration. This was done to prevent footguns where a user attempts to add a callback for a `TypeRegistration` created via `GetTypeRegistration::get_type_registration`, since they'd inadvertently lose any registration callback set by the implementation (including the registration of any type dependencies).

Instead, if users want to completely replace the callback, I added `TypeRegistration::replace_on_register`.

Both methods take `self` and return `Self`, thus adding some amount of assurance that they will not be overwritten by downstream consumers and so that they can be used in the builder pattern for creating a `TypeRegistration`.

This does come at the cost of a `Box` (~8 bytes) per registration, but I think the more consistent API is worth it. Though I'm open to closing this out if we feel this is an unnecessary increase in memory consumption.

## Testing

I added new unit and doc tests in `bevy_reflect`.

---

## Showcase

A `TypeRegistration` can now be given a custom on-registration callback directly:

```rust
let registration = TypeRegistration::of::<MyType>()
  .on_register(|registry| {
    registry.register::<Option<MyType>>();
  });

registry.add_registration(registration);
assert!(registry.contains(TypeId::of::<MyType>()));
assert!(registry.contains(TypeId::of::<Option<MyType>>()));
```
